### PR TITLE
updated mongodb version to 2.2.33 to support atlas

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -104,9 +104,7 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
     sslCert: this.config.sslCert,
     sslKey: this.config.sslKey,
     poolSize: this.config.poolSize,
-    // socketOptions: this.config.socketOptions,
     autoReconnect: this.config.auto_reconnect,
-    // disableDriverBSONSizeCheck: this.config.disableDriverBSONSizeCheck,
     reconnectInterval: this.config.reconnectInterval,
     reconnectTries: this.config.reconnectTries
   });
@@ -115,18 +113,10 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
   connectionOptions = Object.assign(connectionOptions, {
     w: this.config.w,
     wtimeout: this.config.wtimeout,
-    // fsync: this.config.fsync,
-    // journal: this.config.journal,
     readPreference: this.config.readPreference,
     native_parser: this.config.nativeParser,
-    forceServerObjectId: this.config.forceServerObjectId,
-    // recordQueryStats: this.config.recordQueryStats,
-    // retryMiliSeconds: this.config.retryMiliSeconds,
-    // numberOfRetries: this.config.numberOfRetries
+    forceServerObjectId: this.config.forceServerObjectId
   });
-
-  // Support for encoded auth credentials
-  // connectionOptions = Object.assign(connectionOptions, {uri_decode_auth: this.config.uri_decode_auth || false});
 
   // Build A Mongo Connection String
   var connectionString = 'mongodb://';

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,10 +1,9 @@
-
 /**
  * Module dependencies
  */
 
 var async = require('async'),
-    MongoClient = require('mongodb').MongoClient;
+  MongoClient = require('mongodb').MongoClient;
 
 /**
  * Manage a connection to a Mongo Server
@@ -22,8 +21,8 @@ var Connection = module.exports = function Connection(config, cb) {
 
   // Build Database connection
   this._buildConnection(function(err, db) {
-    if(err) return cb(err);
-    if(!db) return cb(new Error('no db object'));
+    if (err) return cb(err);
+    if (!db) return cb(new Error('no db object'));
 
     // Store the DB object
     self.db = db;
@@ -53,7 +52,7 @@ Connection.prototype.createCollection = function createCollection(name, collecti
 
   // Create the Collection
   this.db.createCollection(name, function(err, result) {
-    if(err) return cb(err);
+    if (err) return cb(err);
 
     // Create Indexes
     self._ensureIndexes(result, collection.indexes, cb);
@@ -89,12 +88,15 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
 
   // Set the configured options
   var connectionOptions = {};
-  
-  connectionOptions.mongos = this.config.mongos || {};
-  connectionOptions.replSet = this.config.replSet || {};
+
+  if (this.config.mongos)
+    connectionOptions = Object.assign(connectionOptions, this.config.mongos);
+
+  if (this.config.replSet)
+    connectionOptions = Object.assign(connectionOptions, this.config.replSet);
 
   // Build up options used for creating a Server instance
-  connectionOptions.server = {
+  connectionOptions = Object.assign(connectionOptions, {
     readPreference: this.config.readPreference,
     ssl: this.config.ssl,
     sslValidate: this.config.sslValidate,
@@ -102,38 +104,38 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
     sslCert: this.config.sslCert,
     sslKey: this.config.sslKey,
     poolSize: this.config.poolSize,
-    socketOptions: this.config.socketOptions,
+    // socketOptions: this.config.socketOptions,
     autoReconnect: this.config.auto_reconnect,
-    disableDriverBSONSizeCheck: this.config.disableDriverBSONSizeCheck,
+    // disableDriverBSONSizeCheck: this.config.disableDriverBSONSizeCheck,
     reconnectInterval: this.config.reconnectInterval,
     reconnectTries: this.config.reconnectTries
-  };
+  });
 
   // Build up options used for creating a Database instance
-  connectionOptions.db = {
+  connectionOptions = Object.assign(connectionOptions, {
     w: this.config.w,
     wtimeout: this.config.wtimeout,
-    fsync: this.config.fsync,
-    journal: this.config.journal,
+    // fsync: this.config.fsync,
+    // journal: this.config.journal,
     readPreference: this.config.readPreference,
     native_parser: this.config.nativeParser,
     forceServerObjectId: this.config.forceServerObjectId,
-    recordQueryStats: this.config.recordQueryStats,
-    retryMiliSeconds: this.config.retryMiliSeconds,
-    numberOfRetries: this.config.numberOfRetries
-  };
+    // recordQueryStats: this.config.recordQueryStats,
+    // retryMiliSeconds: this.config.retryMiliSeconds,
+    // numberOfRetries: this.config.numberOfRetries
+  });
 
   // Support for encoded auth credentials
-  connectionOptions.uri_decode_auth = this.config.uri_decode_auth || false;
+  // connectionOptions = Object.assign(connectionOptions, {uri_decode_auth: this.config.uri_decode_auth || false});
 
   // Build A Mongo Connection String
   var connectionString = 'mongodb://';
 
   // If auth is used, append it to the connection string
-  if(this.config.user && this.config.password) {
+  if (this.config.user && this.config.password) {
 
     // Ensure a database was set if auth in enabled
-    if(!this.config.database) {
+    if (!this.config.database) {
       throw new Error('The MongoDB Adapter requires a database config option if authentication is used.');
     }
 
@@ -143,12 +145,12 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
   // Append the host and port
   connectionString += this.config.host + ':' + this.config.port + '/';
 
-  if(this.config.database) {
+  if (this.config.database) {
     connectionString += this.config.database;
   }
 
   // Use config connection string if available
-  if(this.config.url) connectionString = this.config.url;
+  if (this.config.url) connectionString = this.config.url;
 
   // Open a Connection
   MongoClient.connect(connectionString, connectionOptions, cb);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-mongo",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Mongo DB adapter for Sails.js",
   "main": "./lib/adapter.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
-    "mongodb": "2.2.25",
+    "mongodb": "2.2.33",
     "validator": "4.5.1",
     "waterline-cursor": "0.0.7",
     "waterline-errors": "0.10.1"


### PR DESCRIPTION
Removed few options in connection settings which are not supported in the new mongodb version 

1. socketOptions
2. disableDriverBSONSizeCheck
3. fsync
4. journal
5. recordQueryStats
6. retryMiliSeconds
7. numberOfRetries
8. uri_decode_auth
